### PR TITLE
Add Terminal (#18) feature with TDD

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,6 +519,20 @@
           <div class="result" id="result-sqlite"></div>
         </div>
       </div>
+      <!-- #18 Terminal -->
+      <div class="card">
+        <div class="card-header">
+          <div class="card-number">18</div>
+          <span class="card-title">Terminal</span>
+          <span class="card-api">node-pty, xterm.js</span>
+        </div>
+        <div class="card-body">
+          <div class="card-actions">
+            <button id="btn-terminal-open">Open Terminal</button>
+          </div>
+          <div class="result" id="result-terminal"></div>
+        </div>
+      </div>
     </div>
 
     <script src="renderer.js"></script>

--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ const fs = require("fs");
 const os = require("os");
 
 const Database = require("better-sqlite3");
+const pty = require("node-pty");
 
 let mainWindow;
 let tray = null;
@@ -27,6 +28,8 @@ let editorWindow = null;
 let sqliteWindow = null;
 let currentDb = null;
 let currentDbPath = null;
+let terminalWindow = null;
+let terminalPty = null;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -560,6 +563,81 @@ ipcMain.handle("db:openConsole", () => {
   return { id: sqliteWindow.id };
 });
 
+// #18 Terminal
+ipcMain.handle("terminal:open", () => {
+  if (terminalPty) {
+    terminalPty.kill();
+    terminalPty = null;
+  }
+  if (terminalWindow && !terminalWindow.isDestroyed()) {
+    terminalWindow.close();
+  }
+
+  const shell = process.platform === "win32" ? "powershell.exe" : "bash";
+  terminalPty = pty.spawn(shell, [], {
+    name: "xterm-color",
+    cols: 80,
+    rows: 30,
+    cwd: os.homedir(),
+    env: process.env,
+  });
+
+  global.__terminalPty = terminalPty;
+
+  terminalWindow = new BrowserWindow({
+    width: 800,
+    height: 500,
+    parent: mainWindow,
+    modal: false,
+    title: "Terminal",
+    backgroundColor: "#000000",
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  terminalWindow.loadFile("terminal.html", { query: { shell } });
+
+  terminalPty.onData((data) => {
+    if (terminalWindow && !terminalWindow.isDestroyed()) {
+      terminalWindow.webContents.send("terminal:data", data);
+    }
+  });
+
+  terminalPty.onExit(({ exitCode }) => {
+    if (terminalWindow && !terminalWindow.isDestroyed()) {
+      terminalWindow.webContents.send("terminal:exit", exitCode);
+    }
+    terminalPty = null;
+    global.__terminalPty = null;
+  });
+
+  terminalWindow.on("closed", () => {
+    if (terminalPty) {
+      terminalPty.kill();
+      terminalPty = null;
+      global.__terminalPty = null;
+    }
+    terminalWindow = null;
+  });
+
+  return { id: terminalWindow.id, shell };
+});
+
+ipcMain.on("terminal:input", (_, data) => {
+  if (terminalPty) {
+    terminalPty.write(data);
+  }
+});
+
+ipcMain.on("terminal:resize", (_, { cols, rows }) => {
+  if (terminalPty) {
+    terminalPty.resize(cols, rows);
+  }
+});
+
 // =========== App Lifecycle ===========
 
 app.whenReady().then(() => {
@@ -574,6 +652,10 @@ app.whenReady().then(() => {
 
 app.on("will-quit", () => {
   globalShortcut.unregisterAll();
+  if (terminalPty) {
+    terminalPty.kill();
+    terminalPty = null;
+  }
   if (currentDb) {
     currentDb.close();
     currentDb = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "better-sqlite3": "^12.6.2",
-        "monaco-editor": "^0.55.1"
+        "monaco-editor": "^0.55.1",
+        "node-pty": "^1.1.0"
       },
       "devDependencies": {
         "@electron/rebuild": "^4.0.3",
@@ -311,6 +314,21 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/abbrev": {
       "version": "3.0.1",
@@ -1847,6 +1865,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/node-api-version": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
@@ -1932,6 +1956,16 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/nopt": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "electron": "^40.6.1"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "better-sqlite3": "^12.6.2",
-    "monaco-editor": "^0.55.1"
+    "monaco-editor": "^0.55.1",
+    "node-pty": "^1.1.0"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -64,6 +64,16 @@ contextBridge.exposeInMainWorld("electronAPI", {
   dbTables: () => ipcRenderer.invoke("db:tables"),
   dbOpenConsole: () => ipcRenderer.invoke("db:openConsole"),
 
+  // Terminal
+  openTerminal: () => ipcRenderer.invoke("terminal:open"),
+  terminalInput: (data) => ipcRenderer.send("terminal:input", data),
+  terminalResize: (cols, rows) =>
+    ipcRenderer.send("terminal:resize", { cols, rows }),
+  onTerminalData: (cb) =>
+    ipcRenderer.on("terminal:data", (_, data) => cb(data)),
+  onTerminalExit: (cb) =>
+    ipcRenderer.on("terminal:exit", (_, code) => cb(code)),
+
   // Menu action listener
   onMenuAction: (callback) =>
     ipcRenderer.on("menu-action", (_, message) => callback(message)),

--- a/renderer.js
+++ b/renderer.js
@@ -373,6 +373,16 @@ $("btn-db-console").addEventListener("click", async () => {
   }
 });
 
+// #18 Terminal
+$("btn-terminal-open").addEventListener("click", async () => {
+  try {
+    const result = await api.openTerminal();
+    setResult("result-terminal", `Terminal opened (ID: ${result.id})`);
+  } catch (err) {
+    setResult("result-terminal", `Error: ${err.message}`);
+  }
+});
+
 $("btn-browser-dom").addEventListener("click", async () => {
   const result = await api.getBrowserDom();
   if (result.success) {

--- a/terminal-renderer.js
+++ b/terminal-renderer.js
@@ -1,0 +1,50 @@
+const api = window.electronAPI;
+
+const container = document.getElementById("terminal-container");
+const statusEl = document.getElementById("terminal-status");
+
+// Create xterm instance
+const term = new Terminal({
+  cursorBlink: true,
+  fontSize: 14,
+  fontFamily: '"Cascadia Code", "Consolas", "Courier New", monospace',
+  theme: {
+    background: "#000000",
+    foreground: "#e0e0e0",
+  },
+});
+
+// Fit addon for auto-resize
+const fitAddon = new FitAddon.FitAddon();
+term.loadAddon(fitAddon);
+
+// Open terminal in container
+term.open(container);
+fitAddon.fit();
+
+// Send keyboard input to pty
+term.onData((data) => {
+  api.terminalInput(data);
+});
+
+// Receive pty output and write to terminal
+api.onTerminalData((data) => {
+  term.write(data);
+});
+
+// Handle pty exit
+api.onTerminalExit((code) => {
+  term.write(`\r\n[Process exited with code ${code}]\r\n`);
+  statusEl.textContent = `Process exited (code: ${code})`;
+});
+
+// Handle window resize
+window.addEventListener("resize", () => {
+  fitAddon.fit();
+  api.terminalResize(term.cols, term.rows);
+});
+
+// Set status bar with shell info
+const params = new URLSearchParams(window.location.search);
+const shellName = params.get("shell") || "shell";
+statusEl.textContent = shellName;

--- a/terminal.html
+++ b/terminal.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'"
+    />
+    <title>Terminal</title>
+    <link
+      rel="stylesheet"
+      href="node_modules/@xterm/xterm/css/xterm.css"
+    />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        height: 100%;
+        overflow: hidden;
+        background: #000;
+        color: #e0e0e0;
+        font-family: "Segoe UI", -apple-system, sans-serif;
+      }
+
+      #terminal-container {
+        position: absolute;
+        top: 0;
+        bottom: 28px;
+        left: 0;
+        right: 0;
+      }
+
+      #statusbar {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 28px;
+        background: #007acc;
+        display: flex;
+        align-items: center;
+        padding: 0 12px;
+        font-size: 12px;
+        color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="terminal-container"></div>
+    <div id="statusbar"><span id="terminal-status"></span></div>
+
+    <script src="node_modules/@xterm/xterm/lib/xterm.js"></script>
+    <script src="node_modules/@xterm/addon-fit/lib/addon-fit.js"></script>
+    <script src="terminal-renderer.js"></script>
+  </body>
+</html>

--- a/tests/e2e/app-launch.spec.js
+++ b/tests/e2e/app-launch.spec.js
@@ -33,13 +33,13 @@ test("header displays app name", async () => {
   expect(headerText).toBe("Electron Lab");
 });
 
-test("all 17 feature cards are present", async () => {
+test("all 18 feature cards are present", async () => {
   const cards = page.locator(".card");
-  await expect(cards).toHaveCount(17);
+  await expect(cards).toHaveCount(18);
 });
 
 test("each card has a number badge", async () => {
-  for (let i = 1; i <= 17; i++) {
+  for (let i = 1; i <= 18; i++) {
     const badge = page.locator(`.card-number`).filter({ hasText: new RegExp(`^${i}$`) });
     await expect(badge).toBeVisible();
   }

--- a/tests/e2e/terminal.spec.js
+++ b/tests/e2e/terminal.spec.js
@@ -1,0 +1,187 @@
+const { test, expect } = require("@playwright/test");
+const { launchApp, closeApp } = require("./helpers/electron-app");
+
+let electronApp;
+let page;
+
+/**
+ * Helper: close all terminal windows (those loading terminal.html).
+ */
+async function closeTerminalWindows(app) {
+  await app.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows().forEach((w) => {
+      const url = w.webContents.getURL();
+      if (url.includes("terminal.html")) {
+        w.close();
+      }
+    });
+  });
+}
+
+/**
+ * Helper: open terminal window and return its page.
+ */
+async function openTerminalWindow() {
+  const windowPromise = electronApp.waitForEvent("window");
+  await page.click("#btn-terminal-open");
+  const terminalPage = await windowPromise;
+  await terminalPage.waitForLoadState("domcontentloaded");
+  return terminalPage;
+}
+
+test.beforeAll(async () => {
+  ({ electronApp, page } = await launchApp());
+});
+
+test.afterAll(async () => {
+  // Kill pty process if running
+  await electronApp
+    .evaluate(() => {
+      if (global.__terminalPty) {
+        global.__terminalPty.kill();
+        global.__terminalPty = null;
+      }
+    })
+    .catch(() => {});
+  await closeTerminalWindows(electronApp);
+  await closeApp(electronApp);
+});
+
+// --- Test 1: Card #18 is visible ---
+test("card #18 is visible with correct title", async () => {
+  const number = page.locator(".card-number").filter({ hasText: /^18$/ });
+  await expect(number).toBeVisible();
+  const title = page.locator(".card-title").filter({ hasText: "Terminal" });
+  await expect(title).toBeVisible();
+});
+
+// --- Test 2: Terminal window opens ---
+test("opens terminal window on button click", async () => {
+  const terminalPage = await openTerminalWindow();
+  expect(terminalPage).toBeTruthy();
+
+  await page.waitForFunction(() => {
+    const el = document.getElementById("result-terminal");
+    return el && el.textContent.includes("Terminal opened");
+  });
+
+  const result = await page.locator("#result-terminal").textContent();
+  expect(result).toContain("Terminal opened");
+  expect(result).toMatch(/ID: \d+/);
+});
+
+// --- Test 3: xterm.js is rendered ---
+test("xterm.js is rendered in terminal window", async () => {
+  const windows = electronApp.windows();
+  const terminalPage = windows.find((w) => w.url().includes("terminal.html"));
+  expect(terminalPage).toBeTruthy();
+
+  await terminalPage.waitForFunction(
+    () => document.querySelector(".xterm") !== null,
+    { timeout: 15000 }
+  );
+
+  const xtermEl = terminalPage.locator(".xterm");
+  await expect(xtermEl).toBeVisible();
+});
+
+// --- Test 4: Shell output is received ---
+test("receives shell output", async () => {
+  const windows = electronApp.windows();
+  const terminalPage = windows.find((w) => w.url().includes("terminal.html"));
+
+  // Wait for any shell output (prompt or welcome message)
+  await terminalPage.waitForFunction(
+    () => {
+      const el = document.querySelector(".xterm-rows");
+      return el && el.textContent.trim().length > 0;
+    },
+    { timeout: 15000 }
+  );
+
+  const content = await terminalPage.evaluate(() => {
+    const el = document.querySelector(".xterm-rows");
+    return el ? el.textContent : "";
+  });
+  expect(content.trim().length).toBeGreaterThan(0);
+});
+
+// --- Test 5: Keyboard input and echo command ---
+test("keyboard input produces echo output", async () => {
+  const windows = electronApp.windows();
+  const terminalPage = windows.find((w) => w.url().includes("terminal.html"));
+
+  // Wait for shell to be ready (prompt visible)
+  await terminalPage.waitForTimeout(2000);
+
+  // Send input via preload API (xterm uses canvas, keyboard events are unreliable in tests)
+  await terminalPage.evaluate(() => {
+    window.electronAPI.terminalInput("echo HELLO_TERMINAL_TEST\r");
+  });
+
+  // Wait for echo output
+  await terminalPage.waitForFunction(
+    () => {
+      const el = document.querySelector(".xterm-rows");
+      return el && el.textContent.includes("HELLO_TERMINAL_TEST");
+    },
+    { timeout: 15000 }
+  );
+
+  const content = await terminalPage.evaluate(() => {
+    const el = document.querySelector(".xterm-rows");
+    return el ? el.textContent : "";
+  });
+  expect(content).toContain("HELLO_TERMINAL_TEST");
+});
+
+// --- Test 6: Opening new terminal closes previous one ---
+test("opening a new terminal closes the previous one", async () => {
+  // Open second terminal (should close the first)
+  const windowPromise = electronApp.waitForEvent("window");
+  await page.click("#btn-terminal-open");
+  await windowPromise;
+
+  await page.waitForTimeout(500);
+
+  // Count terminal windows
+  const count = await electronApp.evaluate(({ BrowserWindow }) => {
+    return BrowserWindow.getAllWindows().filter((w) => {
+      return w.webContents.getURL().includes("terminal.html");
+    }).length;
+  });
+  expect(count).toBe(1);
+});
+
+// --- Test 7: Closing window cleans up pty process ---
+test("closing window cleans up pty process", async () => {
+  // Close terminal windows
+  await closeTerminalWindows(electronApp);
+  await page.waitForTimeout(500);
+
+  // Verify pty is cleaned up
+  const ptyExists = await electronApp.evaluate(() => {
+    return global.__terminalPty !== null && global.__terminalPty !== undefined;
+  });
+  expect(ptyExists).toBe(false);
+});
+
+// --- Test 8: Status bar shows shell info ---
+test("status bar shows shell information", async () => {
+  // Open a fresh terminal
+  const terminalPage = await openTerminalWindow();
+
+  // Wait for status bar to be populated
+  await terminalPage.waitForFunction(
+    () => {
+      const el = document.getElementById("terminal-status");
+      return el && el.textContent.trim().length > 0;
+    },
+    { timeout: 15000 }
+  );
+
+  const status = await terminalPage.locator("#terminal-status").textContent();
+  expect(status.length).toBeGreaterThan(0);
+  // Should contain shell name (powershell or bash etc.)
+  expect(status.toLowerCase()).toMatch(/powershell|bash|cmd|sh|zsh/);
+});


### PR DESCRIPTION
## Summary
- Embed an interactive terminal in a child window using **xterm.js** (UI) + **node-pty** (pseudo-terminal)
- IPC channels: `terminal:open`, `terminal:input`, `terminal:resize`, `terminal:data`, `terminal:exit`
- Follows existing child-window pattern (Monaco Editor #15, SQLite #17)

## Changes
| File | Description |
|---|---|
| `main.js` | node-pty require, terminal IPC handlers (open/input/resize), pty cleanup |
| `preload.js` | 5 Terminal API methods exposed via contextBridge |
| `index.html` | Card #18 Terminal added |
| `renderer.js` | Open Terminal button handler |
| `terminal.html` | Child window HTML (xterm.css/js, addon-fit) |
| `terminal-renderer.js` | xterm initialization, IPC connection, auto-resize |
| `tests/e2e/terminal.spec.js` | 8 E2E tests |
| `tests/e2e/app-launch.spec.js` | Card count 17 → 18 |
| `package.json` | Added @xterm/xterm, @xterm/addon-fit, node-pty |

## Test plan
- [x] `npx playwright test tests/e2e/terminal.spec.js` — 8 tests pass
- [x] `npm test` — all 105 tests pass (97 existing + 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)